### PR TITLE
Fix CI: Update deprecated GitHub Actions and GeoInterface compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    # Groups all github-actions updates into a single PR
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-          # token: ${{ secrets.CODECOV_TOKEN }} # Not required for public repos
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # Documentation job - commented out until docs/ folder exists

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ on:
       - main
       - master
 
+# Required permissions for modern Julia CI
 permissions:
   actions: write     # Required for julia-actions/cache
   contents: read     # Basic repository read access
@@ -42,13 +43,16 @@ jobs:
             version: 'pre'
     
     steps:
+      # Update to v4 to avoid Node.js deprecation warnings
       - uses: actions/checkout@v4
         
+      # Update to v2 for modern Julia support
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
           
+      # Use julia-actions/cache for better Julia-specific caching
       - uses: julia-actions/cache@v2
         
       # Build package dependencies
@@ -62,56 +66,36 @@ jobs:
       # Process coverage data
       - uses: julia-actions/julia-processcoverage@v1
         
-      # Upload coverage to Codecov
+      # Upload coverage to Codecov (update to v4)
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }} # Not required for public repos
           fail_ci_if_error: false
-          
-      # Upload coverage to Coveralls
-      - uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: lcov.info
-          flag-name: run-${{ matrix.os }}-${{ matrix.version }}
-          parallel: true
 
-  # Finalize Coveralls parallel builds
-  finish:
-    needs: test
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-
-  # Documentation job
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-      statuses: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v2
-      - name: Configure doc environment
-        shell: julia --color=yes --project=docs {0}
-        run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.instantiate()
-      - name: Build and deploy documentation
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: |
-          julia --color=yes --project=docs docs/make.jl
+  # Documentation job - commented out until docs/ folder exists
+  # docs:
+  #   name: Documentation
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     pull-requests: read
+  #     statuses: write
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: julia-actions/setup-julia@v2
+  #       with:
+  #         version: '1'
+  #     - uses: julia-actions/cache@v2
+  #     - name: Configure doc environment
+  #       shell: julia --color=yes --project=docs {0}
+  #       run: |
+  #         using Pkg
+  #         Pkg.develop(PackageSpec(path=pwd()))
+  #         Pkg.instantiate()
+  #     - name: Build and deploy documentation
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  #       run: |
+  #         julia --color=yes --project=docs docs/make.jl

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
         
       # Upload coverage to Codecov (update to v4)
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,48 +1,117 @@
 name: CI
+
 on:
   push:
-    branches: [main]
-    tags: ["*"]
+    branches:
+      - main
+      - master
   pull_request:
+    branches:
+      - main
+      - master
+
+permissions:
+  actions: write     # Required for julia-actions/cache
+  contents: read     # Basic repository read access
+  pull-requests: read
+  statuses: write
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'nightly'
+          - 'lts'        # Latest LTS release
+          - '1'          # Latest stable 1.x release  
+          - 'pre'        # Pre-release (nightly)
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
-          - x86
         exclude:
+          # Exclude some combinations to save CI time
           - os: macOS-latest
-            arch: x86
+            version: 'pre'
+          - os: windows-latest
+            version: 'pre'
+    
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+        
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          
+      - uses: julia-actions/cache@v2
+        
+      # Build package dependencies
       - uses: julia-actions/julia-buildpkg@v1
+        
+      # Run tests with annotations for better error reporting
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
         with:
-          file: lcov.info
+          annotate: true
+          
+      # Process coverage data
+      - uses: julia-actions/julia-processcoverage@v1
+        
+      # Upload coverage to Codecov
+      - uses: codecov/codecov-action@v4
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          
+      # Upload coverage to Coveralls
+      - uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info
+          flag-name: run-${{ matrix.os }}-${{ matrix.version }}
+          parallel: true
+
+  # Finalize Coveralls parallel builds
+  finish:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+
+  # Documentation job
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Configure doc environment
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - name: Build and deploy documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: |
+          julia --color=yes --project=docs docs/make.jl

--- a/src/KML.jl
+++ b/src/KML.jl
@@ -726,10 +726,10 @@ for T in vcat(all_concrete_subtypes(KMLElement), all_abstract_subtypes(Object))
     end
 end
 
-# Add this type-level implementation for GeoInterface v1.x
+# Add this type-level implementation for GeoInterface v1.x 
 GeoInterface.isgeometry(::Type{<:Geometry}) = true
 
-# Add the missing ncoord implementations for GeoInterface v1.x
+# Add the missing ncoord implementations for GeoInterface v1.x 
 GeoInterface.ncoord(::GeoInterface.LineStringTrait, ls::LineString) = 2
 GeoInterface.ncoord(::GeoInterface.LinearRingTrait, lr::LinearRing) = 2
 

--- a/src/KML.jl
+++ b/src/KML.jl
@@ -726,4 +726,11 @@ for T in vcat(all_concrete_subtypes(KMLElement), all_abstract_subtypes(Object))
     end
 end
 
+# Add this type-level implementation for GeoInterface v1.x
+GeoInterface.isgeometry(::Type{<:Geometry}) = true
+
+# Add the missing ncoord implementations for GeoInterface v1.x
+GeoInterface.ncoord(::GeoInterface.LineStringTrait, ls::LineString) = 2
+GeoInterface.ncoord(::GeoInterface.LinearRingTrait, lr::LinearRing) = 2
+
 end #module


### PR DESCRIPTION
### Changes
- Updated GitHub Actions to latest versions (v1→v4/v5) to fix deprecation warnings
- Added workflow permissions and Dependabot config
- Implemented missing GeoInterface v1.x traits to fix test failures

### Fixes
- CI should now trigger on PRs (fixes issue affecting #14)
- All tests pass
- No more Node.js deprecation warnings

### Note
Codecov v5 requires `CODECOV_TOKEN` secret

Tested successfully on my fork.